### PR TITLE
Added `ErrorPage`

### DIFF
--- a/Public/css/main.css
+++ b/Public/css/main.css
@@ -131,3 +131,9 @@ footer {
         flex-basis: 100%;
     }
 }
+
+/* Error Page Styles */
+
+.error {
+    text-align: center;
+}

--- a/Sources/App/Views/Pages/ErrorPage.swift
+++ b/Sources/App/Views/Pages/ErrorPage.swift
@@ -1,0 +1,49 @@
+import Plot
+import PlotVapor
+import Vapor
+
+struct ErrorPage: TemplatedPage {
+    let title: String
+    let message: String
+
+    var content: Component {
+        Div {
+            Div {
+                Image("/images/logo.png")
+                    .class("logo")
+                
+                H1 {
+                    Text(self.title)
+                }
+                
+                Paragraph(self.message)
+                
+                Link("Take me back home!", url: "/")
+            }
+            .class("error")
+        }
+        .class("container")
+    }
+    
+    /// Initializes an `ErrorPage` with a given title and message.
+    /// - Parameters:
+    ///   - title: The title to display, both for the URL bar and the view.
+    ///   - message: The message to display in the view.
+    init(title: String, message: String) {
+        self.title = title
+        self.message = message
+    }
+    
+    /// Initializes an `ErrorPage` using defaults based off of an `HTTPResponseStatus`.
+    /// If the `HTTPResponseStatus` does not have valid defaults, the initializer will return `nil`.
+    /// - Parameter status: The `HTTPResponseStatus` to fetch defaults for.
+    init?(_ status: HTTPResponseStatus) {
+        switch status {
+        case .notFound:
+            self.title = "Page Not Found"
+            self.message = "The page you're looking for can't be found."
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/App/Views/Pages/HomePage.swift
+++ b/Sources/App/Views/Pages/HomePage.swift
@@ -6,11 +6,15 @@ struct HomePage: TemplatedPage {
     let title = "Home"
 
     var content: Component {
-        Div {
-            Intro()
-            ProjectFeed()
-            Footer()
+        ComponentGroup {
+            Div {
+                Intro()
+                
+                ProjectFeed()
+                
+                Footer()
+            }
+            .class("container")
         }
-        .class("container")
     }
 }

--- a/Sources/App/Views/Pages/HomePage.swift
+++ b/Sources/App/Views/Pages/HomePage.swift
@@ -6,15 +6,11 @@ struct HomePage: TemplatedPage {
     let title = "Home"
 
     var content: Component {
-        ComponentGroup {
-            Div {
-                Intro()
-                
-                ProjectFeed()
-                
-                Footer()
-            }
-            .class("container")
+        Div {
+            Intro()
+            ProjectFeed()
+            Footer()
         }
+        .class("container")
     }
 }

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -6,4 +6,13 @@ func routes(_ app: Application) throws {
     
     // Register controllers on subpaths.
     try app.routes.grouped("status").register(collection: StatusController())
+    
+    
+    app.get("**") { req -> View in
+        if let errorPage = ErrorPage(.notFound) {
+            return try await req.plot.render(errorPage)
+        } else {
+            throw Abort(.notFound)
+        }
+    }
 }

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -7,7 +7,6 @@ func routes(_ app: Application) throws {
     // Register controllers on subpaths.
     try app.routes.grouped("status").register(collection: StatusController())
     
-    
     app.get("**") { req -> View in
         if let errorPage = ErrorPage(.notFound) {
             return try await req.plot.render(errorPage)


### PR DESCRIPTION
Added an `ErrorPage` template with default settings for `HTTPResponseStatus.notfound`.

This will only work properly so long as the `app.get("")` registration is last on the list.